### PR TITLE
Free dependencies

### DIFF
--- a/tests/testthat/package/DESCRIPTION
+++ b/tests/testthat/package/DESCRIPTION
@@ -6,7 +6,7 @@ Authors@R: person("Ashley", "Baldry", email = "arbaldry91@gmail.com", role = c("
 Description: A way to check R packages and shiny applications for unused package dependencies, or packages
     with low usage. Reduces the requirement to have unneccessary dependencies in a project.
 License: MIT + file LICENSE
-Imports: formatR, testthat
+Imports: formatR, testthat, digest
 Encoding: UTF-8
 Language: en-GB
 Suggests: covr

--- a/tests/testthat/package/R/test.R
+++ b/tests/testthat/package/R/test.R
@@ -9,3 +9,11 @@ test2 <- function() {
 test3 <- function() {
   testthat::expect_false(FALSE)
 }
+
+test3 <- function() {
+  testthat::expect_equal(5, 5)
+}
+
+digest_function <- function() {
+  digest::digest("fd")
+}

--- a/tests/testthat/r_files/test.R
+++ b/tests/testthat/r_files/test.R
@@ -1,3 +1,19 @@
 test1 <- function() {
   print("This is a test chunk of code")
 }
+
+test2 <- function() {
+  testthat::expect_true(TRUE)
+}
+
+test3 <- function() {
+  testthat::expect_false(FALSE)
+}
+
+test3 <- function() {
+  testthat::expect_equal(5, 5)
+}
+
+digest_function <- function() {
+  digest::digest("fd")
+}

--- a/tests/testthat/test-check_package_use.R
+++ b/tests/testthat/test-check_package_use.R
@@ -5,6 +5,9 @@ testthat::test_that("getPackageFunctions fails for non-existent package", {
   )
 })
 
+testthat::skip_if_offline("cran.rstudio.com")
+options(repos = "https://cran.rstudio.com/")
+
 testthat::test_that("getPackageFunctions returns character vector of functions in package", {
   functions <- getPackageFunctions("utils")
 

--- a/tests/testthat/test-dependency_use.R
+++ b/tests/testthat/test-dependency_use.R
@@ -1,0 +1,34 @@
+testthat::test_that("Dependency check works for package", {
+  package_dependency_use <- depcheck::checkPackageDependencyUse("package", verbose = FALSE)
+  testthat::expect_s3_class(package_dependency_use, "multi_package_usage")
+})
+
+testthat::test_that("Dependency check finds correct function use", {
+  package_dependency_use <- depcheck::checkPackageDependencyUse("package", verbose = FALSE)
+
+  testthat::expect_equal(sum(package_dependency_use$formatR$function_usage), 0)
+
+  digest_use <- package_dependency_use$digest
+  digest_use <- digest_use[digest_use$function_usage > 0, ]
+  testthat::expect_equal(digest_use$function_name, "digest")
+
+  testthat::expect_equal(sum(package_dependency_use$testthat$function_usage), 3)
+  testthat_use <- package_dependency_use$testthat
+  testthat_use <- testthat_use[testthat_use$function_usage > 0, ]
+  testthat::expect_equal(sort(testthat_use$function_name), c("expect_equal", "expect_false", "expect_true"))
+})
+
+testthat::test_that("Dependency check shows low use package", {
+  package_dependency_use <- depcheck::checkPackageDependencyUse("package", verbose = FALSE)
+  testthat::expect_message(print(package_dependency_use), "formatR")
+})
+
+testthat::test_that("Dependency check does not show low use of free dependency package", {
+  package_dependency_use <- depcheck::checkPackageDependencyUse("package", verbose = FALSE)
+  testthat::expect_message(print(package_dependency_use), "^((?!digest).)*$", perl = TRUE)
+})
+
+testthat::test_that("Dependency check works for project", {
+  project_dependency_use <- depcheck::checkProjectDependencyUse("r_files", verbose = FALSE)
+  testthat::expect_s3_class(project_dependency_use, "multi_package_usage")
+})


### PR DESCRIPTION
Enable low use dependencies to not be flagged if parent dependency is frequently used in package/project